### PR TITLE
Multi instance

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
     "requirements": {
         "yunohost": ">> 2.4.0"
     },
-    "multi_instance": false,
+    "multi_instance": true,
     "services": [
         "nginx"
     ],

--- a/scripts/install
+++ b/scripts/install
@@ -58,17 +58,17 @@ sudo yunohost firewall allow TCP $port > /dev/null 2>&1
 INSTALL_DUNITER_DEBIAN_PACKAGE
 
 # Configure Duniter node
-sudo $app config --ipv4 127.0.0.1 --port $port --remoteh $domain --remotep 443 --noupnp
+sudo duniter config --ipv4 127.0.0.1 --port $port --remoteh $domain --remotep 443 --noupnp
 
 # Reset Duniter node's existing data (blockchain, not conf)
-sudo $app reset data > /dev/null
+sudo duniter reset data > /dev/null
 
 # Synchronize Duniter node
 echo "Synchronizing with $sync_node:$sync_port. It may take a while."
-sudo $app sync $sync_node $sync_port --nointeractive > /dev/null
+sudo duniter sync $sync_node $sync_port --nointeractive > /dev/null
 
 # Launch Duniter node
-sudo $app webstart
+sudo duniter webstart
 
 # Add Duniter service to the YunoHost monitoring
 sudo yunohost service add $app --log /home/admin/.config/$app/"$app"_default/"$app".log

--- a/scripts/remove
+++ b/scripts/remove
@@ -11,8 +11,8 @@ domain=$(ynh_app_setting_get $app domain)
 port=$(ynh_app_setting_get $app port)
 
 # Remove Duniter
-sudo $app stop
-sudo dpkg -r $app
+sudo duniter stop
+sudo dpkg -r duniter
 
 # Remove data and conf
 sudo rm -rf /root/.conf/duniter

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -16,7 +16,7 @@ admin=$(ynh_app_setting_get "$app" admin)
 is_cesium_public=$(ynh_app_setting_get "$app" is_cesium_public)
 
 # Stop duniter daemon
-sudo $app stop
+sudo duniter stop
 
 # Remove Duniter package
 sudo dpkg -r duniter
@@ -24,7 +24,7 @@ sudo dpkg -r duniter
 INSTALL_DUNITER_DEBIAN_PACKAGE
 
 # Start duniter daemon
-sudo $app webstart
+sudo duniter webstart
 
 CONFIG_SSOWAT_FOR_RESTRICTED_ACCESS
 CONFIG_NGINX_FOR_WEB_ADMIN


### PR DESCRIPTION
- [ ] handle database name and path with `--mdb $app` option with every `duniter` command.
- [ ] use `duniter_default` database name for first instance to facilitate CLI manipulation.
- [ ] handle upgrade from `duniter_default` database to `duniter__1`, `duniter__2`…etc
- [ ] remove debian package only if it's the last duniter installed app.